### PR TITLE
Prevent mutation of `mixture` objects outside of `VerletWeis` scope 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mixscatter"
-version = "0.2.3"
+version = "0.2.4"
 description = """\
 A versatile tool for calculating scattering functions of particle mixtures, \
 particularly for small-angle scattering (SAS) or static and dynamic light scattering (SLS & DLS) \

--- a/src/mixscatter/core.py
+++ b/src/mixscatter/core.py
@@ -200,11 +200,13 @@ def measurable_diffusion_coefficient(
         ...     scattering_model, thermal_energy=1.0, viscosity=1.0
         ... )
     """
-    weighted_inverse_radius: NDArray[np.float64] = np.sum(
-        scattering_model.mixture.number_fraction[:, np.newaxis]
-        * scattering_model.amplitude**2
-        / scattering_model.mixture.radius[:, np.newaxis],
-        axis=0,
+    weighted_inverse_radius: NDArray[np.float64] = np.asanyarray(
+        np.sum(
+            scattering_model.mixture.number_fraction[:, np.newaxis]
+            * scattering_model.amplitude**2
+            / scattering_model.mixture.radius[:, np.newaxis],
+            axis=0,
+        ),
         dtype=np.float64,
     )
     weighted_inverse_radius /= scattering_model.average_square_amplitude

--- a/src/mixscatter/liquidstructure/liquidstructure.py
+++ b/src/mixscatter/liquidstructure/liquidstructure.py
@@ -133,7 +133,7 @@ class LiquidStructure(ABC):
         unity_tensor_qij = np.eye(self.mixture.number_of_components)[np.newaxis, :, :]
         S_inv_qij = unity_tensor_qij - c_weighted_qij
         S_qij = np.linalg.solve(S_inv_qij, unity_tensor_qij)
-        S_ijq = np.moveaxis(S_qij, 0, -1)
+        S_ijq = np.asanyarray(np.moveaxis(S_qij, 0, -1), dtype=np.float64)
         return S_ijq
 
     @cached_property

--- a/src/mixscatter/liquidstructure/liquidstructure.py
+++ b/src/mixscatter/liquidstructure/liquidstructure.py
@@ -20,6 +20,7 @@ References:
 from abc import ABC, abstractmethod
 from functools import cached_property
 from typing import Protocol, runtime_checkable
+from copy import deepcopy
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -276,7 +277,7 @@ class PercusYevick(LiquidStructure):
 
 class VerletWeis(PercusYevick):
     """
-    Hard-sphere potential in the Percus-Yevick approximation employing the Verlet-Weiss correction.
+    Hard-sphere potential in the Percus-Yevick approximation employing the Verlet-Weis correction.
 
     Uses the PercusYevick class with an effective volume fraction and an effective radius.
 
@@ -296,13 +297,16 @@ class VerletWeis(PercusYevick):
         """
         effective_volume_fraction = volume_fraction_total * (1.0 - volume_fraction_total / 16.0)
         effective_radius = mixture.radius * (effective_volume_fraction / volume_fraction_total) ** (1.0 / 3.0)
-
+        effective_mixture = deepcopy(mixture)
         # Some static type checkers at the moment cannot handle protocols implementing property setters
         # and since a mutable radius property is only needed here, a manual isinstance assertion is performed
-        if isinstance(mixture, HasMutableRadius) and getattr(type(mixture), "radius").fset is not None:
-            mixture.radius = effective_radius
-            assert isinstance(mixture, MixtureLike)
+        if (
+            isinstance(effective_mixture, HasMutableRadius)
+            and getattr(type(effective_mixture), "radius").fset is not None
+        ):
+            effective_mixture.radius = effective_radius
+            assert isinstance(effective_mixture, MixtureLike)
         else:
             raise AttributeError("`radius` property of `mixture` must be mutable.")
 
-        super().__init__(wavevector, mixture, volume_fraction_total=effective_volume_fraction)
+        super().__init__(wavevector, effective_mixture, volume_fraction_total=effective_volume_fraction)

--- a/src/mixscatter/mixture/mixture.py
+++ b/src/mixscatter/mixture/mixture.py
@@ -191,13 +191,14 @@ class FlorySchulzMixture(Mixture):
         cls, number_of_components: int, mean_radius: float, shape_parameter: float
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         roots, weights = cls._generalized_laguerre_weights(number_of_components, shape_parameter)
-        scaled_roots = roots * mean_radius / (shape_parameter + 1.0)
+        scaled_roots = np.asanyarray(roots * mean_radius / (shape_parameter + 1.0), dtype=np.float64)
         weights /= np.sum(weights)
         return scaled_roots, weights
 
     @staticmethod
     def _generalized_laguerre_weights(order: int, exponent: float) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         roots, *_ = roots_genlaguerre(order, exponent)
+        roots = np.asanyarray(roots, dtype=np.float64)
         values_at_roots = eval_genlaguerre(order + 1, exponent, roots)
         abs_values_at_roots = np.abs(values_at_roots)
         log_weights = np.log(roots) - 2.0 * np.log(abs_values_at_roots)

--- a/src/mixscatter/scatteringmodel/scatteringmodel.py
+++ b/src/mixscatter/scatteringmodel/scatteringmodel.py
@@ -694,8 +694,8 @@ class ScatteringModel:
         Returns:
             The average squared scattering amplitude.
         """
-        average_square_amplitude: NDArray[np.float64] = np.sum(
-            self.mixture.number_fraction[:, np.newaxis] * self.amplitude**2, axis=0, dtype=np.float64
+        average_square_amplitude: NDArray[np.float64] = np.asanyarray(
+            np.sum(self.mixture.number_fraction[:, np.newaxis] * self.amplitude**2, axis=0), dtype=np.float64
         )
         return average_square_amplitude
 
@@ -706,8 +706,8 @@ class ScatteringModel:
         Returns:
             The average squared forward scattering amplitude.
         """
-        average_square_forward_amplitude: float = np.sum(
-            self.mixture.number_fraction * self.forward_amplitude**2, axis=0, dtype=np.float64
+        average_square_forward_amplitude = float(
+            np.sum(self.mixture.number_fraction * self.forward_amplitude**2, axis=0)
         )
         return average_square_forward_amplitude
 
@@ -718,7 +718,8 @@ class ScatteringModel:
         Returns:
             The average form factor.
         """
-        return self.average_square_amplitude / self.average_square_forward_amplitude
+
+        return np.asanyarray(self.average_square_amplitude / self.average_square_forward_amplitude, dtype=np.float64)
 
     @cached_property
     def square_radius_of_gyration(self) -> NDArray[np.float64]:
@@ -736,18 +737,14 @@ class ScatteringModel:
     @cached_property
     def average_square_radius_of_gyration(self) -> float:
         """
-        Computes the average, apparent radius of gyration of the system. The apparent radius of gyration
-        determines the initial slope of the average form factor.
+        Computes the average, apparent radius of gyration of the system. The apparent radius of
+        gyration determines the initial slope of the average form factor.
 
         Returns:
              The average radius of gyration of the system.
         """
-        average_square_radius_of_gyration: float = (
-            np.sum(
-                self.mixture.number_fraction * self.forward_amplitude**2 * self.square_radius_of_gyration,
-                axis=0,
-                dtype=np.float64,
-            )
+        average_square_radius_of_gyration: float = float(
+            np.sum(self.mixture.number_fraction * self.forward_amplitude**2 * self.square_radius_of_gyration, axis=0)
             / self.average_square_forward_amplitude
         )
         return average_square_radius_of_gyration

--- a/tests/test_liquid_structure.py
+++ b/tests/test_liquid_structure.py
@@ -98,7 +98,7 @@ def test_percus_yevick_compressibility_structure_factor(mock_mixture):
     assert_array_almost_equal(S_compressibility_q, np.array([0.021, 1.138, 0.994]), decimal=3)
 
 
-def test_percus_yevick_verlet_weiss_initialization(mock_mixture):
+def test_percus_yevick_verlet_weiss_initialization():
     class MutableMixture(MixtureLike):
         def __init__(self, radius):
             self._radius = np.array(radius)
@@ -116,9 +116,11 @@ def test_percus_yevick_verlet_weiss_initialization(mock_mixture):
     volume_fraction_total = 0.3
     pyvw = VerletWeis(wavevector, mixture, volume_fraction_total)
     assert np.allclose(pyvw.wavevector, [0.1, 0.2, 0.3])
-    assert pyvw.mixture == mixture
     assert pyvw.volume_fraction_total == pytest.approx(volume_fraction_total * (1 - volume_fraction_total / 16))
     assert_array_almost_equal(pyvw.mixture.radius, np.array([0.994, 1.987]), decimal=3)
+
+    # Assert that the original mixture is unaltered
+    assert_array_almost_equal(mixture.radius, np.array([1.0, 2.0]), decimal=3)
 
 
 def test_verlet_weis_without_mutable_radius():
@@ -131,7 +133,7 @@ def test_verlet_weis_without_mutable_radius():
             return self._radius
 
     wavevector = [0.1, 0.2, 0.3]
-    mixture = ImmutableMixture(radius=np.array([0.1, 0.2, 0.3]))
+    mixture = ImmutableMixture(radius=np.array([1.0, 2.0]))
     # Should raise a TypeError
     with pytest.raises(AttributeError, match="`radius` property of `mixture` must be mutable."):
         VerletWeis(wavevector, mixture, 0.5)


### PR DESCRIPTION
Previously, a `Mixture` instance passed into `VerletWeis` would be mutated during initialization. Now, a deep copy of the `Mixture` instance is processed instead and the passed reference is unaltered.